### PR TITLE
Fix number_of_selfloops() call for recent networkx versions

### DIFF
--- a/nxpd/nx_pydot.py
+++ b/nxpd/nx_pydot.py
@@ -246,7 +246,7 @@ def to_pydot(G, raise_exceptions=True):
     else:
         graph_type = 'graph'
 
-    strict = G.number_of_selfloops() == 0 and not G.is_multigraph()
+    strict = nx.number_of_selfloops(G) == 0 and not G.is_multigraph()
 
     # Create the Pydot graph.
     name = G.graph.get('name')

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 def main():
 
     install_requires = [
-        'networkx >= 1.6',
+        'networkx >= 2.0',
         'pyparsing >= 2.0.1',
     ]
 


### PR DESCRIPTION
The number_of_selfloops() graph method was deprecated in the networkx
2.0 release[1] which was released in 2017 and replaced with a
function that provides the same functionality. In the recent 2.4 release
this deprecated method has been removed. This commit updates the use of
number_of_selfloops to use that function instead of the deprecated and
now removed method. It also increases the minimum version supported by
the library to use 2.0 which was the version this function was
introduced.

Fixes #14

[1] https://networkx.github.io/documentation/stable/release/release_2.0.html#api-changes